### PR TITLE
Use forEach instead of map

### DIFF
--- a/o.mjs
+++ b/o.mjs
@@ -301,8 +301,8 @@ export const render = (vlist, dom, ns) => {
   });
   // Iterate over all hooks, if a hook has a useEffect callback set - call it
   // (since the rendering is now done) and remove.
-  Object.values(dom.h).map(componentHooks =>
-    componentHooks.map(h => h.cb && ((h.cleanup = h.cb()), (h.cb = 0)))
+  Object.values(dom.h).forEach(componentHooks =>
+    componentHooks.forEach(h => h.cb && ((h.cleanup = h.cb()), (h.cb = 0)))
   );
   // For all hooks present in the DOM node before rendering, but not present
   // after - call the cleanup callbacks, if any. This means the corresponding
@@ -311,7 +311,7 @@ export const render = (vlist, dom, ns) => {
   // simple.
   Object.keys(hs)
     .filter(k => !dom.h[k])
-    .map(k => hs[k].map(h => h.cleanup && h.cleanup()));
+    .forEach(k => hs[k].forEach(h => h.cleanup && h.cleanup()));
   for (let child; (child = dom.childNodes[vlist.length]); ) {
     render([], dom.removeChild(child));
   }


### PR DESCRIPTION
`map`'s return value is being ignored, so `forEach` is more efficient and semantically appropriate here.